### PR TITLE
인사이트 낡음 경고, 마케팅 차트, AI 프롬프트 고도화

### DIFF
--- a/scripts/preview-prompt.ts
+++ b/scripts/preview-prompt.ts
@@ -1,0 +1,65 @@
+/**
+ * AI 인사이트 프롬프트 미리보기.
+ * 실행: npx tsx scripts/preview-prompt.ts [year] [month]
+ * 예시: npx tsx scripts/preview-prompt.ts 2026 2
+ */
+import { resolve } from "path";
+import { existsSync, readFileSync } from "fs";
+
+// .env.local 수동 로드 (동적 import 전에 실행해야 함)
+const envPath = resolve(process.cwd(), ".env.local");
+if (existsSync(envPath)) {
+  for (const line of readFileSync(envPath, "utf-8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const val = trimmed.slice(eqIdx + 1).trim();
+    if (!process.env[key]) process.env[key] = val;
+  }
+}
+
+async function main() {
+  // 환경변수 로드 후 동적 import (config.ts가 process.env를 읽을 수 있도록)
+  const { loadReport, loadRecentHistory, listReports } = await import("../src/lib/storage/report-store");
+  const { buildOverviewData } = await import("../src/lib/calculations/overview");
+  const { buildPrompt } = await import("../src/lib/ai/insights");
+
+  const year = Number(process.argv[2]) || 2026;
+  const month = Number(process.argv[3]) || 2;
+
+  const report = await loadReport(year, month);
+  if (!report) {
+    console.error(`❌ ${year}년 ${month}월 레포트 없음`);
+    process.exit(1);
+  }
+
+  const history = await loadRecentHistory(year, month, 3);
+
+  const allList = await listReports();
+  const allReports = (
+    await Promise.all(allList.map(({ year: y, month: m }) => loadReport(y, m)))
+  ).filter((r): r is NonNullable<typeof r> => r !== null);
+  const { months: overview } = buildOverviewData(allReports);
+
+  const { insights: _, ...reportWithoutInsights } = report;
+  const prompt = buildPrompt(reportWithoutInsights, history, overview);
+
+  console.log("=".repeat(80));
+  console.log("📋 SYSTEM PROMPT (시스템 프롬프트는 insights.ts의 SYSTEM_PROMPT 상수 참고)");
+  console.log("=".repeat(80));
+  console.log();
+  console.log("=".repeat(80));
+  console.log(`📊 USER PROMPT (${year}년 ${month}월)`);
+  console.log("=".repeat(80));
+  console.log();
+  console.log(`다음 판매 데이터를 분석하여 핵심 인사이트 7~12개를 JSON 배열로 제공해주세요.\n`);
+  console.log(prompt);
+  console.log();
+  console.log("=".repeat(80));
+  console.log(`📏 프롬프트 길이: ${prompt.length}자`);
+  console.log("=".repeat(80));
+}
+
+main().catch(console.error);

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { generateSalesInsights } from "@/lib/ai/insights";
-import { loadReport, loadRecentHistory, updateReport } from "@/lib/storage/report-store";
+import { loadReport, loadRecentHistory, listReports, updateReport } from "@/lib/storage/report-store";
+import { buildOverviewData } from "@/lib/calculations/overview";
 import { ENABLE_AI_INSIGHTS } from "@/lib/config";
 
 /**
@@ -43,10 +44,21 @@ export async function POST(request: NextRequest) {
     // 최대 3개월 히스토리 로드 [전달, 전전달, 전전전달]
     const history = await loadRecentHistory(year, month, 3);
 
-    const insights = await generateSalesInsights(report, history);
+    // 전체 기간 개요 데이터 로드 (장기 추세 분석용)
+    const allList = await listReports();
+    const allReports = (
+      await Promise.all(allList.map(({ year: y, month: m }) => loadReport(y, m)))
+    ).filter((r): r is NonNullable<typeof r> => r !== null);
+    const { months: overview } = buildOverviewData(allReports);
+
+    const insights = await generateSalesInsights(report, history, overview);
     const updated = await updateReport(year, month, { insights });
 
-    return NextResponse.json({ insights: updated.insights });
+    return NextResponse.json({
+      insights: updated.insights,
+      insightsGeneratedAt: updated.insightsGeneratedAt,
+      lastModifiedAt: updated.lastModifiedAt,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "인사이트 생성 실패";
     console.error("[POST /api/insights] 인사이트 생성 실패");

--- a/src/app/api/scrape/route.ts
+++ b/src/app/api/scrape/route.ts
@@ -125,6 +125,7 @@ export async function POST(request: NextRequest) {
       sponsorship,
       ...derived,
       insights: existing?.insights ?? [],
+      insightsGeneratedAt: existing?.insightsGeneratedAt,
       warnings: raw.warnings,
       collectedAt: timestamp,
       lastModifiedAt: timestamp,

--- a/src/app/monthly/page.tsx
+++ b/src/app/monthly/page.tsx
@@ -130,8 +130,10 @@ export default function MonthlyPage() {
         const data = await res.json();
         throw new Error(data.error ?? "인사이트 생성 실패");
       }
-      const { insights } = await res.json();
-      setReport((prev) => (prev ? { ...prev, insights } : prev));
+      const { insights, insightsGeneratedAt, lastModifiedAt } = await res.json();
+      setReport((prev) =>
+        prev ? { ...prev, insights, insightsGeneratedAt, lastModifiedAt } : prev
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "인사이트 생성 중 오류가 발생했습니다.");
     }
@@ -287,6 +289,8 @@ export default function MonthlyPage() {
 
           <InsightsSection
             insights={report.insights}
+            insightsGeneratedAt={report.insightsGeneratedAt}
+            lastModifiedAt={report.lastModifiedAt}
             onRegenerate={handleRegenerate}
           />
         </>

--- a/src/components/dashboard/InsightsSection.tsx
+++ b/src/components/dashboard/InsightsSection.tsx
@@ -73,12 +73,29 @@ function renderBoldText(text: string) {
   );
 }
 
+/** ISO 타임스탬프 → "3월 1일 15:30 생성" */
+function formatGeneratedAt(iso: string): string {
+  const d = new Date(iso);
+  const m = d.getMonth() + 1;
+  const day = d.getDate();
+  const h = d.getHours();
+  const min = String(d.getMinutes()).padStart(2, "0");
+  return `${m}월 ${day}일 ${h}:${min} 생성`;
+}
+
 interface Props {
   insights: SalesInsight[];
+  insightsGeneratedAt?: string;
+  lastModifiedAt?: string;
   onRegenerate: () => Promise<void>;
 }
 
-export default function InsightsSection({ insights, onRegenerate }: Props) {
+export default function InsightsSection({
+  insights,
+  insightsGeneratedAt,
+  lastModifiedAt,
+  onRegenerate,
+}: Props) {
   const [regenerating, setRegenerating] = useState(false);
 
   const handleRegenerate = async () => {
@@ -89,6 +106,13 @@ export default function InsightsSection({ insights, onRegenerate }: Props) {
       setRegenerating(false);
     }
   };
+
+  // 낡음 판단: 인사이트 생성 이후 데이터가 변경됐는지
+  const isStale =
+    insights.length > 0 &&
+    !!insightsGeneratedAt &&
+    !!lastModifiedAt &&
+    lastModifiedAt !== insightsGeneratedAt;
 
   // 타입별 그룹핑
   const grouped = TYPE_ORDER.map((type) => ({
@@ -101,18 +125,41 @@ export default function InsightsSection({ insights, onRegenerate }: Props) {
     <section>
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold text-gray-800">AI 인사이트</h3>
-        <button
-          onClick={handleRegenerate}
-          disabled={regenerating}
-          className="text-sm text-brand-500 hover:text-brand-700 disabled:opacity-40 transition-colors"
-        >
-          {regenerating
-            ? "생성 중..."
-            : insights.length === 0
-              ? "생성"
-              : "재생성"}
-        </button>
+        <div className="flex items-center gap-3">
+          {/* 생성 시각 (fresh 상태일 때만) */}
+          {insights.length > 0 && insightsGeneratedAt && !isStale && (
+            <span className="text-xs text-gray-400">
+              {formatGeneratedAt(insightsGeneratedAt)}
+            </span>
+          )}
+          <button
+            onClick={handleRegenerate}
+            disabled={regenerating}
+            className="px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-brand-500 text-white hover:bg-brand-600"
+          >
+            {regenerating
+              ? "생성 중..."
+              : insights.length === 0
+                ? "인사이트 생성"
+                : "재생성"}
+          </button>
+        </div>
       </div>
+
+      {/* 낡음 경고 배너 */}
+      {isStale && (
+        <div className="mb-4 px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg">
+          <p className="text-sm text-amber-700">
+            <span className="mr-1.5">&#9888;</span>
+            인사이트 생성 이후 데이터가 변경되었습니다.
+            {insightsGeneratedAt && (
+              <span className="text-amber-500 ml-1.5 text-xs">
+                ({formatGeneratedAt(insightsGeneratedAt)})
+              </span>
+            )}
+          </p>
+        </div>
+      )}
 
       {insights.length === 0 ? (
         <Card className="py-12 text-center">

--- a/src/components/insights/ChartsSection.tsx
+++ b/src/components/insights/ChartsSection.tsx
@@ -28,6 +28,10 @@ const CHARTS: { title: string; Component: ComponentType<ChartProps> }[] = [
     title: "월별 마진율",
     Component: dynamic(() => import("./MarginChart"), { ssr: false, loading }),
   },
+  {
+    title: "월별 마케팅 비용",
+    Component: dynamic(() => import("./MarketingCostChart"), { ssr: false, loading }),
+  },
 ];
 
 export default function ChartsSection({ data }: ChartProps) {

--- a/src/components/insights/MarketingCostChart.tsx
+++ b/src/components/insights/MarketingCostChart.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  LabelList,
+} from "recharts";
+import { MonthlyOverview } from "@/lib/types";
+import { formatKRW } from "@/lib/utils/format";
+import { CHART_MARGIN, GRID_PROPS, X_TICK, Y_TICK, LABEL_STYLE } from "./chart-config";
+
+interface Props {
+  data: MonthlyOverview[];
+}
+
+export default function MarketingCostChart({ data }: Props) {
+  // 마케팅 비용 합계 계산
+  const chartData = data.map((m) => ({
+    ...m,
+    totalMarketingCost: m.naverAdFee + m.coupangAdFee + m.sponsorshipCost,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={chartData} margin={CHART_MARGIN}>
+        <CartesianGrid {...GRID_PROPS} />
+        <XAxis dataKey="label" tick={X_TICK} />
+        <YAxis
+          tickFormatter={(v) =>
+            v >= 10000 ? `${Math.round(v / 10000)}만` : `${v}`
+          }
+          tick={Y_TICK}
+          width={52}
+        />
+        <Tooltip
+          formatter={(value: number | undefined, name: string | undefined) => [
+            formatKRW(value ?? 0),
+            name ?? "",
+          ]}
+        />
+        <Legend />
+        <Bar
+          dataKey="naverAdFee"
+          name="네이버 광고비"
+          stackId="marketing"
+          fill="#637AB9"
+          radius={[0, 0, 0, 0]}
+        />
+        <Bar
+          dataKey="coupangAdFee"
+          name="쿠팡 광고비"
+          stackId="marketing"
+          fill="#4FB7B3"
+          radius={[0, 0, 0, 0]}
+        />
+        <Bar
+          dataKey="sponsorshipCost"
+          name="협찬 마케팅"
+          stackId="marketing"
+          fill="#A8FBD3"
+          radius={[4, 4, 0, 0]}
+        >
+          <LabelList
+            dataKey="totalMarketingCost"
+            position="top"
+            formatter={(v: unknown) => {
+              const val = (v as number) ?? 0;
+              if (val === 0) return "";
+              return val >= 10000
+                ? `${Math.round(val / 10000)}만`
+                : formatKRW(val);
+            }}
+            style={{ ...LABEL_STYLE, fill: "#374151" }}
+          />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/lib/ai/insights.ts
+++ b/src/lib/ai/insights.ts
@@ -1,4 +1,4 @@
-import { MonthlyReport, SalesInsight } from "@/lib/types";
+import { MonthlyReport, MonthlyOverview, SalesInsight } from "@/lib/types";
 import { formatKRW } from "@/lib/utils/format";
 import { GROQ_API_KEY, AI_MODEL } from "@/lib/config";
 
@@ -63,7 +63,7 @@ function profitMargin(revenue: number, netProfit: number): string {
 
 /** 광고 효율 (ROAS = 매출 / 광고비) */
 function calcROAS(revenue: number, adFee: number): string {
-  if (adFee === 0) return "N/A (광고비 없음)";
+  if (adFee === 0) return "해당 없음 (광고 미집행)";
   return (revenue / adFee).toFixed(1);
 }
 
@@ -308,11 +308,73 @@ ${droppedFromTop.length > 0 ? `- TOP5 이탈: ${droppedFromTop.map((r) => `${r.p
   return `## 5. 월별 추이 및 전달 비교\n\n${trendTable}\n\n${detailComparison}`;
 }
 
+// ─── 전체 기간 개요 섹션 ──────────────────────────────────────────────
+
+function buildOverviewSection(
+  report: Report,
+  overview: MonthlyOverview[]
+): string {
+  // 당월 포함 최소 3개월 이상일 때만 의미 있음
+  if (overview.length < 3) return "";
+
+  const header = overview.map((m) => m.label).join(" | ");
+  const separator = overview.map(() => "---").join(" | ");
+
+  const row = (label: string, fn: (m: MonthlyOverview) => string) =>
+    `| ${label} | ${overview.map(fn).join(" | ")} |`;
+
+  const table = `| 지표 | ${header} |
+| --- | ${separator} |
+${row("매출", (m) => formatKRW(m.totalRevenue))}
+${row("순이익", (m) => formatKRW(m.totalNetProfit))}
+${row("마진율", (m) => `${m.marginRate}%`)}
+${row("판매량", (m) => `${m.totalQuantity}개`)}
+${row("끈갈피", (m) => `${m.handmadeQuantity}개`)}
+${row("네이버 매출", (m) => formatKRW(m.naverRevenue))}
+${row("쿠팡 매출", (m) => formatKRW(m.coupangRevenue))}
+${row("오프라인 매출", (m) => formatKRW(m.offlineRevenue))}
+${row("네이버 광고비", (m) => formatKRW(m.naverAdFee))}
+${row("쿠팡 광고비", (m) => formatKRW(m.coupangAdFee))}
+${row("협찬 비용", (m) => formatKRW(m.sponsorshipCost))}
+${row("마케팅 합계", (m) => formatKRW(m.naverAdFee + m.coupangAdFee + m.sponsorshipCost))}
+${row("광고비/매출 비율", (m) => {
+    const adTotal = m.naverAdFee + m.coupangAdFee;
+    return m.totalRevenue > 0 ? `${((adTotal / m.totalRevenue) * 100).toFixed(1)}%` : "0%";
+  })}`;
+
+  // 전체 누적 요약
+  const totals = overview.reduce(
+    (acc, m) => ({
+      revenue: acc.revenue + m.totalRevenue,
+      netProfit: acc.netProfit + m.totalNetProfit,
+      quantity: acc.quantity + m.totalQuantity,
+    }),
+    { revenue: 0, netProfit: 0, quantity: 0 }
+  );
+  const avgMargin =
+    totals.revenue > 0
+      ? Math.round((totals.netProfit / totals.revenue) * 1000) / 10
+      : 0;
+
+  return `## 6. 전체 기간 개요 (${overview.length}개월)
+
+${table}
+
+### 누적 요약
+- 누적 매출: ${formatKRW(totals.revenue)}
+- 누적 순이익: ${formatKRW(totals.netProfit)}
+- 평균 마진율: ${avgMargin}%
+- 누적 판매량: ${totals.quantity}개
+
+이 데이터를 바탕으로 장기적 매출 추세, 마진율 변화 패턴, 채널별 성장/하락 추이 등 전체 기간에서 주목할 점이 있다면 분석해주세요.`;
+}
+
 // ─── 프롬프트 통합 ─────────────────────────────────────────────────────
 
-function buildPrompt(
+export function buildPrompt(
   report: Report,
-  history?: (Report | null)[]
+  history?: (Report | null)[],
+  overview?: MonthlyOverview[]
 ): string {
   const sections = [
     buildPeriodSection(report),
@@ -321,6 +383,7 @@ function buildPrompt(
     buildProductSection(report),
     buildSponsorshipSection(report),
     history ? buildTrendSection(report, history) : "",
+    overview ? buildOverviewSection(report, overview) : "",
   ];
 
   return sections.filter(Boolean).join("\n\n");
@@ -342,19 +405,65 @@ const SYSTEM_PROMPT = `당신은 핸드메이드 끈갈피(비즈 책갈피) 판
 3. 우선순위 명시: 가장 효과가 클 것으로 보이는 액션을 먼저 제안
 4. 솔직한 평가: 좋은 점만이 아니라 문제점도 명확히 지적
 
+## 언어 규칙 (필수)
+- 반드시 순수 한글로만 작성하세요
+- 한자(漢字), 일본어(ひらがな/カタカナ) 절대 사용 금지
+- 예: "前月" → "지난달", "分析" → "분석", "增加" → "증가", "效果" → "효과"
+- 전문 용어도 한글로 풀어서 작성: "MoM" → "전달 대비", "YoY" → "전년 대비"
+
 ## 필수 분석 카테고리 (각 카테고리에서 최소 1개 인사이트)
 1. **revenue**: 전체 및 플랫폼별 매출 동향
 2. **profit**: 이익률 분석 (플랫폼별 이익률 차이, 비용 구조 문제점)
 3. **product**: 어떤 상품을 전략적으로 밀어야 할지 (TOP 상품, 성장 잠재력 있는 상품)
 4. **platform**: 플랫폼별 성과 비교 및 채널 전략
-5. **ad**: 광고 효율 분석 (ROAS가 낮으면 광고 중단/축소 권고)
+5. **ad**: 광고 효율 분석 (광고를 집행한 플랫폼만 분석)
 6. **sponsorship**: 협찬 마케팅 효과 분석 (데이터가 있는 경우에만)
 7. **trend**: 전달 대비 변화 트렌드 (이전 달 데이터가 있는 경우에만)
+8. **overview**: 전체 기간 누적 추이에서 주목할 만한 패턴 (전체 개요 데이터가 있는 경우에만)
 
-## 광고 효율 판단 기준
-- ROAS 3.0 미만: 광고 효율이 낮으므로 축소 또는 중단 권고
+## 광고 및 마케팅 비용 분석 규칙
+
+### 기본 원칙
+- 광고비가 0원인 플랫폼은 "해당 월에 광고를 집행하지 않은 것"으로 판단
+- "광고를 안 하고 있으니 해야 한다"처럼 단순 제안하지 말 것
+- 반드시 전체 기간 개요의 광고비·매출·마진율 추이를 함께 비교하여 근거 기반으로 판단할 것
+
+### 광고 미집행 시 판단 프로세스
+1. 전체 기간에서 광고를 했던 달과 안 했던 달의 매출 차이를 비교
+2. 광고를 했을 때 매출 증가폭 vs 광고비 지출을 비교하여 실제 이익 기여도를 계산
+3. 광고 집행 달의 마진율 변화를 확인 (매출이 늘어도 마진율이 크게 떨어지면 주의)
+4. 이 근거를 바탕으로 결론 도출:
+   - 광고 시 매출 증가가 유의미하고 마진율 유지 → 광고 재개 권고
+   - 광고 시 매출 증가가 미미하거나 마진율 하락 → 광고보다 다른 전략(상품 개선, 채널 확대 등) 제안
+   - 데이터 부족 → 소규모 테스트 광고 후 효과 측정 권고
+
+### 광고 집행 시 ROAS 기준
+- ROAS 3.0 미만: 효율이 낮으므로 키워드/타겟 재검토 또는 축소 권고
 - ROAS 3.0~5.0: 보통 수준, 키워드 최적화 권고
 - ROAS 5.0 이상: 양호, 예산 확대 검토 가능
+
+### 마케팅 비용 전체 판단
+- 광고비 + 협찬 비용 합계가 매출 대비 몇 %인지 확인
+- 마케팅 비용 대비 매출 증가 효율을 월별로 비교
+- 협찬과 광고 중 어떤 마케팅이 더 비용 효율적인지 비교 분석
+
+## 변화 원인 분석 (필수)
+매출, 판매량, 마진율이 증가하거나 감소했을 때 반드시 "왜 그런지"를 유추하세요.
+단순히 "감소했다"가 아니라 가능한 원인을 데이터와 맥락 기반으로 설명해야 합니다.
+
+### 확인할 원인 후보
+1. **광고비 변화**: 광고 중단/축소로 노출이 줄어 매출 감소, 또는 광고 시작으로 매출 증가
+2. **협찬 효과**: 협찬 리뷰 게시 후 1~2개월 뒤 판매 증가, 또는 협찬 미진행으로 노출 감소
+3. **달력 요인**: 2월은 28일(또는 29일)로 다른 달보다 2~3일 짧아 매출 감소 가능. 1월/5월/9월 등 연휴가 많은 달은 사람들이 외출/여행을 하면서 온라인 쇼핑이 줄어드는 경향이 있음
+4. **계절/시즌 요인**: 연말(11~12월) 선물 수요 증가, 연초(1~2월) 소비 심리 위축, 여름/겨울 방학 시즌 독서량 변화
+5. **플랫폼 비용 구조 변화**: 수수료율 변화, 물류비 변동 등이 마진율에 영향
+6. **상품 구성 변화**: 인기 상품의 판매 증감, 신상품 효과, 특정 상품 품절 등
+
+### 분석 방법
+- 전체 기간 개요 데이터에서 같은 달(전년 동월)이 있으면 계절적 패턴인지 비교
+- 광고비가 줄거나 0이 된 달과 매출 감소가 동시에 일어났는지 확인
+- 협찬을 진행한 다음 달에 해당 상품 판매가 늘었는지 확인
+- 여러 원인이 복합적으로 작용했을 가능성도 언급 (예: "2월은 일수가 적은 데다 광고도 미집행하여 복합적으로 영향")
 
 ## 협찬 마케팅 지연 효과
 - 협찬 리뷰의 판매 전환 효과는 1~2개월 뒤에 나타남
@@ -364,7 +473,7 @@ const SYSTEM_PROMPT = `당신은 핸드메이드 끈갈피(비즈 책갈피) 판
 
 ## 출력 형식
 반드시 아래 JSON 배열 형식으로만 출력하세요. 추가 설명 없이 JSON만 반환하세요.
-인사이트는 7~10개를 생성하세요.
+인사이트는 7~12개를 생성하세요. 전체 기간 개요 데이터가 있으면 장기 추세 인사이트도 포함하세요.
 
 description 안에서 핵심 수치, 상품명, 행동 권장 사항은 **볼드 마커**로 강조하세요.
 예시: "매출이 **153,000원에서 220,000원으로 43.8% 증가**했으며, **쿠팡 채널 집중 노출**을 권장합니다."
@@ -374,7 +483,7 @@ description 안에서 핵심 수치, 상품명, 행동 권장 사항은 **볼드
     "title": "인사이트 제목 (15자 이내, 핵심 키워드 포함)",
     "description": "구체적인 설명과 행동 권장 사항 (150자 이내, 수치 포함, **핵심 강조**)",
     "type": "positive | negative | neutral | action",
-    "category": "revenue | profit | product | platform | ad | sponsorship | trend"
+    "category": "revenue | profit | product | platform | ad | sponsorship | trend | overview"
   }
 ]
 
@@ -389,18 +498,20 @@ type 분류:
 /**
  * Groq API (Llama 3.3)를 사용해 월간 판매 인사이트 생성.
  * history: [전달, 전전달, 전전전달] 순. 없으면 당월 데이터만으로 분석.
+ * overview: 전체 기간 월별 개요 데이터 (장기 추세 분석용).
  */
 export async function generateSalesInsights(
   report: Report,
-  history?: (Report | null)[]
+  history?: (Report | null)[],
+  overview?: MonthlyOverview[]
 ): Promise<SalesInsight[]> {
-  const prompt = buildPrompt(report, history);
+  const prompt = buildPrompt(report, history, overview);
 
   const text = await callGroq([
     { role: "system", content: SYSTEM_PROMPT },
     {
       role: "user",
-      content: `다음 판매 데이터를 분석하여 핵심 인사이트 7~10개를 JSON 배열로 제공해주세요.\n\n${prompt}`,
+      content: `다음 판매 데이터를 분석하여 핵심 인사이트 7~12개를 JSON 배열로 제공해주세요.\n\n${prompt}`,
     },
   ]);
 

--- a/src/lib/calculations/overview.ts
+++ b/src/lib/calculations/overview.ts
@@ -28,6 +28,10 @@ export function buildOverviewData(reports: MonthlyReport[]): OverviewResponse {
         (s: number, v: { revenue: number }) => s + v.revenue,
         0
       ),
+      // 마케팅 비용
+      naverAdFee: r.naver.fees.adFee,
+      coupangAdFee: r.coupang.fees.adFee,
+      sponsorshipCost: r.sponsorship?.marketingCost ?? 0,
     }))
     .sort((a, b) =>
       a.period.year !== b.period.year

--- a/src/lib/storage/report-store.ts
+++ b/src/lib/storage/report-store.ts
@@ -343,13 +343,17 @@ export async function updateReport(
     platforms.naver, platforms.coupang, platforms.offline, sponsorship, mapping
   );
 
+  const now = new Date().toISOString();
   const updated: MonthlyReport = {
     ...existing,
     ...platforms,
     sponsorship,
     ...derived,
     insights: updates.insights ?? existing.insights,
-    lastModifiedAt: new Date().toISOString(),
+    insightsGeneratedAt: updates.insights
+      ? now
+      : existing.insightsGeneratedAt,
+    lastModifiedAt: now,
   };
 
   await saveReport(updated);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -176,6 +176,10 @@ export interface MonthlyOverview {
   naverRevenue: number;
   coupangRevenue: number;
   offlineRevenue: number;
+  // 마케팅 비용
+  naverAdFee: number;
+  coupangAdFee: number;
+  sponsorshipCost: number;    // 협찬 마케팅 비용 (부자재비)
 }
 
 /** GET /api/overview 응답 타입 */
@@ -219,6 +223,7 @@ export interface MonthlyReport {
   sponsorExcludedRanking: ProductRankEntry[]; // 협찬 제외 TOP5
   productMatrix: ProductMatrixRow[]; // 상품 × 플랫폼 표
   insights: SalesInsight[];
+  insightsGeneratedAt?: string; // ISO 8601 — 인사이트가 마지막으로 생성된 시각
   warnings: ScrapeWarning[];  // 수집 시 경고
   collectedAt: string; // ISO 8601
   lastModifiedAt: string; // ISO 8601


### PR DESCRIPTION
## Summary
- 인사이트 생성 후 데이터 변경 시 노란색 경고 배너 표시 (insightsGeneratedAt 기반 staleness 감지)
- 월별 마케팅 비용(네이버/쿠팡 광고비, 협찬) 누적 막대 차트 추가
- AI 프롬프트에 전체 기간 개요 데이터 전달 및 변화 원인 분석 규칙 추가

## Test plan
- [x] 인사이트 생성 → 생성 시각 표시 확인
- [x] 수기 편집 후 → 경고 배너 표시 확인
- [x] 경고 상태에서 재생성 → 경고 사라짐 확인
- [x] 마케팅 비용 차트 정상 렌더링 확인
- [x] `npx tsx scripts/preview-prompt.ts 2026 2`로 프롬프트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)