### PR TITLE
feat: 협찬 자동 계산 + API 연동 + 쿠팡 입고 배송비

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "dev",
       "runtimeExecutable": "node_modules/.bin/next",
       "runtimeArgs": ["dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": false
     }
   ]
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,29 @@
       "Bash(npx tsc --noEmit 2>&1)",
       "Bash(node_modules/.bin/tsc --noEmit 2>&1)",
       "Bash(npm install --silent 2>&1 | tail -5)",
-      "mcp__playwright__browser_evaluate"
+      "mcp__playwright__browser_evaluate",
+      "Bash(gh label:*)",
+      "Bash(npm install:*)",
+      "Bash(npx vitest:*)",
+      "Bash(npx tsx:*)",
+      "Bash(npm uninstall:*)",
+      "Bash(node:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "WebSearch",
+      "WebFetch(domain:developers.coupangcorp.com)",
+      "WebFetch(domain:www.sellerking.io)",
+      "Bash(git checkout:*)",
+      "mcp__Claude_Preview__preview_start",
+      "Bash(kill 28353)",
+      "Bash(kill -9 28353)",
+      "Bash(find /Users/ihyewon/custom-revenue-tracker/data/reports -type f -name *.json)",
+      "Bash(grep -r coupang-sales --include=*.ts)",
+      "Bash(gh pr:*)",
+      "Bash(git worktree *)",
+      "Bash(git branch *)",
+      "Bash(rm -rf .claude/plans .claude/worktrees)"
     ]
   }
 }

--- a/src/components/dashboard/EditableField.tsx
+++ b/src/components/dashboard/EditableField.tsx
@@ -14,7 +14,11 @@ interface Props {
  * Enter / blur → onSave 호출 → 저장 완료 후 원래 표시로 복귀.
  * Escape → 취소.
  */
-export default function EditableField({ value, onSave, className = "" }: Props) {
+export default function EditableField({
+  value,
+  onSave,
+  className = "",
+}: Props) {
   const [editing, setEditing] = useState(false);
   const [inputVal, setInputVal] = useState("");
   const [saving, setSaving] = useState(false);
@@ -50,7 +54,7 @@ export default function EditableField({ value, onSave, className = "" }: Props) 
           if (e.key === "Enter") commit();
           if (e.key === "Escape") setEditing(false);
         }}
-        className={`w-32 border-b-2 border-brand-400 outline-none bg-brand-50 px-1 py-0.5 text-right font-semibold text-sm ${className}`}
+        className={`w-32 -mr-1 border-b-2 border-brand-400 outline-none bg-brand-50 px-1 py-0.5 text-right font-semibold text-sm ${className}`}
         disabled={saving}
       />
     );
@@ -60,7 +64,7 @@ export default function EditableField({ value, onSave, className = "" }: Props) 
     <button
       onClick={startEdit}
       title="클릭하여 편집"
-      className={`hover:bg-brand-50 hover:text-brand-600 rounded px-1 py-0.5 transition-colors cursor-text text-right font-semibold text-sm ${saving ? "opacity-40" : ""} ${className}`}
+      className={`-mr-1 hover:bg-brand-50 hover:text-brand-600 rounded px-1 py-0.5 transition-colors cursor-text text-right font-semibold text-sm ${saving ? "opacity-40" : ""} ${className}`}
     >
       <KRWText n={value} />
     </button>

--- a/src/components/dashboard/PlatformSection.tsx
+++ b/src/components/dashboard/PlatformSection.tsx
@@ -131,7 +131,7 @@ function CoupangCard({
         }));
       await onUpdate({ coupang: { products } });
     },
-    [editList, onUpdate]
+    [editList, onUpdate],
   );
 
   return (
@@ -155,6 +155,13 @@ function CoupangCard({
       <Row
         label="풀필먼트 물류비"
         value={<KRWText n={data.fees.logisticsFee} />}
+      />
+      <EditRow
+        label="입고 배송비"
+        value={data.fees.inboundShippingFee}
+        onSave={(v) =>
+          onUpdate({ coupang: { fees: { inboundShippingFee: v } } })
+        }
       />
       <Row label="광고비" value={<KRWText n={data.fees.adFee} />} />
 
@@ -212,7 +219,7 @@ function OfflineCard({
         }));
       await onUpdate({ offline: { products } });
     },
-    [productMatrix, onUpdate]
+    [productMatrix, onUpdate],
   );
 
   const isGosan = data.venueId === "gosan";
@@ -317,10 +324,10 @@ export default function PlatformSection({
     totalCards <= 2
       ? "grid-cols-1 md:grid-cols-2"
       : totalCards === 3
-      ? "grid-cols-1 md:grid-cols-3"
-      : totalCards === 4
-      ? "grid-cols-1 md:grid-cols-2 xl:grid-cols-4"
-      : "grid-cols-1 md:grid-cols-2 lg:grid-cols-3";
+        ? "grid-cols-1 md:grid-cols-3"
+        : totalCards === 4
+          ? "grid-cols-1 md:grid-cols-2 xl:grid-cols-4"
+          : "grid-cols-1 md:grid-cols-2 lg:grid-cols-3";
 
   return (
     <section>

--- a/src/lib/ai/insights.ts
+++ b/src/lib/ai/insights.ts
@@ -19,7 +19,7 @@ interface GroqResponse {
 async function callGroq(messages: GroqMessage[]): Promise<string> {
   if (!GROQ_API_KEY) {
     throw new Error(
-      "GROQ_API_KEY 환경변수가 설정되지 않았습니다. .env.local에 추가하세요."
+      "GROQ_API_KEY 환경변수가 설정되지 않았습니다. .env.local에 추가하세요.",
     );
   }
 
@@ -117,6 +117,7 @@ function buildPlatformSection(report: Report): string {
 - 매출: ${formatKRW(coupang.revenue)}
 - 수수료: ${formatKRW(coupang.fees.commissionFee)}
 - 풀필먼트 물류비: ${formatKRW(coupang.fees.logisticsFee)}
+- 입고 배송비: ${formatKRW(coupang.fees.inboundShippingFee)}
 - 광고비: ${formatKRW(coupang.fees.adFee)}
 - 이익: ${formatKRW(coupang.profit.profit)} / 순이익: ${formatKRW(coupang.profit.netProfit)}
 - 이익률: ${profitMargin(coupang.revenue, coupang.profit.netProfit)}%
@@ -132,7 +133,7 @@ function buildPlatformSection(report: Report): string {
 - 광고비: ${formatKRW(v.fees.adFee)}
 - 이익: ${formatKRW(v.profit.profit)} / 순이익: ${formatKRW(v.profit.netProfit)}
 - 이익률: ${profitMargin(v.revenue, v.profit.netProfit)}%
-- 판매량: 전체 ${v.totalQuantity}개 · 끈갈피 ${v.handmadeQuantity}개`
+- 판매량: 전체 ${v.totalQuantity}개 · 끈갈피 ${v.handmadeQuantity}개`,
     )
     .join("\n\n");
 
@@ -170,7 +171,7 @@ function buildProductSection(report: Report): string {
       ? overallRanking
           .map(
             (r) =>
-              `${r.rank}위. ${r.productName}: 총 ${r.total}개 (N:${r.naver} / C:${r.coupang} / O:${r.offline})`
+              `${r.rank}위. ${r.productName}: 총 ${r.total}개 (N:${r.naver} / C:${r.coupang} / O:${r.offline})`,
           )
           .join("\n")
       : "데이터 없음";
@@ -189,7 +190,7 @@ function buildProductSection(report: Report): string {
       ? activeProducts
           .map(
             (p) =>
-              `- ${p.productName}: 총 ${p.total}개 (N:${p.naver} / C:${p.coupang} / O:${p.offline})`
+              `- ${p.productName}: 총 ${p.total}개 (N:${p.naver} / C:${p.coupang} / O:${p.offline})`,
           )
           .join("\n")
       : "데이터 없음";
@@ -231,25 +232,17 @@ function buildSponsorshipSection(report: Report): string {
 }
 
 /** 히스토리에서 존재하는 레포트만 시간 역순으로 정렬 (과거→현재) */
-function validHistory(
-  report: Report,
-  history: (Report | null)[]
-): Report[] {
+function validHistory(report: Report, history: (Report | null)[]): Report[] {
   const past = history.filter((r): r is Report => r !== null).reverse();
   return [...past, report];
 }
 
-function buildTrendSection(
-  report: Report,
-  history: (Report | null)[]
-): string {
+function buildTrendSection(report: Report, history: (Report | null)[]): string {
   const timeline = validHistory(report, history);
   if (timeline.length < 2) return "";
 
   // 3개월 추이 테이블
-  const header = timeline
-    .map((r) => `${r.period.month}월`)
-    .join(" | ");
+  const header = timeline.map((r) => `${r.period.month}월`).join(" | ");
   const separator = timeline.map(() => "---").join(" | ");
 
   const row = (label: string, fn: (r: Report) => string) =>
@@ -276,10 +269,10 @@ ${row("협찬 수량", (r) => `${r.sponsorship?.totalQuantity ?? 0}개`)}`;
   const prevTopNames = new Set(prev.overallRanking.map((r) => r.productName));
   const currTopNames = new Set(report.overallRanking.map((r) => r.productName));
   const newInTop = report.overallRanking.filter(
-    (r) => !prevTopNames.has(r.productName)
+    (r) => !prevTopNames.has(r.productName),
   );
   const droppedFromTop = prev.overallRanking.filter(
-    (r) => !currTopNames.has(r.productName)
+    (r) => !currTopNames.has(r.productName),
   );
 
   // 협찬 지연 효과: 이전 달 협찬 상품이 당월에 얼마나 팔렸는지
@@ -290,7 +283,9 @@ ${row("협찬 수량", (r) => `${r.sponsorship?.totalQuantity ?? 0}개`)}`;
     const delayRows = prevSponsoredNames
       .map((name) => {
         const currRow = currentMatrix.find((p) => p.productName === name);
-        const prevRow = (prev.productMatrix ?? []).find((p) => p.productName === name);
+        const prevRow = (prev.productMatrix ?? []).find(
+          (p) => p.productName === name,
+        );
         return `- ${name}: 전달 ${prevRow?.total ?? 0}개 → 당월 ${currRow?.total ?? 0}개`;
       })
       .join("\n");
@@ -315,7 +310,7 @@ ${droppedFromTop.length > 0 ? `- TOP5 이탈: ${droppedFromTop.map((r) => `${r.p
 
 function buildOverviewSection(
   report: Report,
-  overview: MonthlyOverview[]
+  overview: MonthlyOverview[],
 ): string {
   // 당월 포함 최소 3개월 이상일 때만 의미 있음
   if (overview.length < 3) return "";
@@ -341,9 +336,11 @@ ${row("쿠팡 광고비", (m) => formatKRW(m.coupangAdFee))}
 ${row("협찬 비용", (m) => formatKRW(m.sponsorshipCost))}
 ${row("마케팅 합계", (m) => formatKRW(m.naverAdFee + m.coupangAdFee + m.sponsorshipCost))}
 ${row("광고비/매출 비율", (m) => {
-    const adTotal = m.naverAdFee + m.coupangAdFee;
-    return m.totalRevenue > 0 ? `${((adTotal / m.totalRevenue) * 100).toFixed(1)}%` : "0%";
-  })}`;
+  const adTotal = m.naverAdFee + m.coupangAdFee;
+  return m.totalRevenue > 0
+    ? `${((adTotal / m.totalRevenue) * 100).toFixed(1)}%`
+    : "0%";
+})}`;
 
   // 전체 누적 요약
   const totals = overview.reduce(
@@ -352,7 +349,7 @@ ${row("광고비/매출 비율", (m) => {
       netProfit: acc.netProfit + m.totalNetProfit,
       quantity: acc.quantity + m.totalQuantity,
     }),
-    { revenue: 0, netProfit: 0, quantity: 0 }
+    { revenue: 0, netProfit: 0, quantity: 0 },
   );
   const avgMargin =
     totals.revenue > 0
@@ -377,7 +374,7 @@ ${table}
 export function buildPrompt(
   report: Report,
   history?: (Report | null)[],
-  overview?: MonthlyOverview[]
+  overview?: MonthlyOverview[],
 ): string {
   const sections = [
     buildPeriodSection(report),
@@ -532,7 +529,7 @@ interface TypeDeficit {
 function findTypeDeficit(insights: SalesInsight[]): TypeDeficit {
   const actionCount = insights.filter((i) => i.type === "action").length;
   const posNegCount = insights.filter(
-    (i) => i.type === "positive" || i.type === "negative"
+    (i) => i.type === "positive" || i.type === "negative",
   ).length;
 
   return {
@@ -544,7 +541,7 @@ function findTypeDeficit(insights: SalesInsight[]): TypeDeficit {
 /** 부족한 타입만 보충 요청하는 프롬프트 생성 */
 function buildSupplementPrompt(
   existing: SalesInsight[],
-  deficit: TypeDeficit
+  deficit: TypeDeficit,
 ): string {
   const existingList = existing
     .map((i) => `- [${i.type}] ${i.title}`)
@@ -553,13 +550,11 @@ function buildSupplementPrompt(
   const requests: string[] = [];
   if (deficit.action > 0) {
     requests.push(
-      `- **action** 타입 ${deficit.action}개 (구체적이고 즉시 실행 가능한 액션)`
+      `- **action** 타입 ${deficit.action}개 (구체적이고 즉시 실행 가능한 액션)`,
     );
   }
   if (deficit.posNeg > 0) {
-    requests.push(
-      `- **positive 또는 negative** 타입 ${deficit.posNeg}개`
-    );
+    requests.push(`- **positive 또는 negative** 타입 ${deficit.posNeg}개`);
   }
 
   return `기존에 생성된 인사이트:
@@ -678,7 +673,7 @@ function parseInsightsJson(text: string): SalesInsight[] | null {
 export async function generateSalesInsights(
   report: Report,
   history?: (Report | null)[],
-  overview?: MonthlyOverview[]
+  overview?: MonthlyOverview[],
 ): Promise<SalesInsight[]> {
   const prompt = buildPrompt(report, history, overview);
 

--- a/src/lib/calculations/overview.test.ts
+++ b/src/lib/calculations/overview.test.ts
@@ -36,12 +36,21 @@ function makeReport(overrides: {
     marketingCost = 0,
   } = overrides;
 
-  const emptyFees = { commissionFee: 0, logisticsFee: 0, adFee: 0, settlementAmount: 0 };
+  const emptyFees = {
+    commissionFee: 0,
+    logisticsFee: 0,
+    inboundShippingFee: 0,
+    adFee: 0,
+    settlementAmount: 0,
+  };
   const emptyProfit = { profit: 0, materialCost: 0, netProfit: 0 };
 
   return {
     period: { year, month },
-    dataRange: { start: `${year}-${String(month).padStart(2, "0")}-01`, end: `${year}-${String(month).padStart(2, "0")}-28` },
+    dataRange: {
+      start: `${year}-${String(month).padStart(2, "0")}-01`,
+      end: `${year}-${String(month).padStart(2, "0")}-28`,
+    },
     naver: {
       revenue: naverRevenue,
       shippingCollected: 0,
@@ -74,11 +83,17 @@ function makeReport(overrides: {
       profit: emptyProfit,
       products: [],
     })),
-    sponsorship: { items: [], marketingCost, totalQuantity: 0, handmadeQuantity: 0 },
+    sponsorship: {
+      items: [],
+      marketingCost,
+      totalQuantity: 0,
+      handmadeQuantity: 0,
+    },
     summary: {
       totalRevenue,
       totalCommissionFee: 0,
       totalLogisticsFee: 0,
+      totalInboundShippingFee: 0,
       totalAdFee: 0,
       totalProfit: 0,
       totalMaterialCost: 0,

--- a/src/lib/calculations/product.test.ts
+++ b/src/lib/calculations/product.test.ts
@@ -6,7 +6,6 @@ import {
   jaccardSimilarity,
   cleanProductName,
   toCanonical,
-  STOP_WORDS,
 } from "./product";
 import type { ProductSales, ProductMappingConfig } from "@/lib/types";
 

--- a/src/lib/calculations/profit.test.ts
+++ b/src/lib/calculations/profit.test.ts
@@ -21,6 +21,7 @@ function makeFees(overrides: Partial<PlatformFees> = {}): PlatformFees {
   return {
     commissionFee: 0,
     logisticsFee: 0,
+    inboundShippingFee: 0,
     adFee: 0,
     settlementAmount: 0,
     ...overrides,
@@ -28,7 +29,7 @@ function makeFees(overrides: Partial<PlatformFees> = {}): PlatformFees {
 }
 
 function makeOfflineVenue(
-  overrides: Partial<OfflineData> & { venueId: string }
+  overrides: Partial<OfflineData> & { venueId: string },
 ): OfflineData {
   return {
     venueName: overrides.venueId,
@@ -295,7 +296,12 @@ describe("calcOverallSummary", () => {
   });
 
   test("marketingCost가 있으면 totalNetProfit에서 차감한다", () => {
-    const result = calcOverallSummary(naverData, coupangData, offlineVenues, 5000);
+    const result = calcOverallSummary(
+      naverData,
+      coupangData,
+      offlineVenues,
+      5000,
+    );
     expect(result.marketingCost).toBe(5000);
     expect(result.totalNetProfit).toBe(165800); // 170800 - 5000
   });

--- a/src/lib/calculations/profit.ts
+++ b/src/lib/calculations/profit.ts
@@ -30,10 +30,14 @@ export function calcPlatformProfit(
   revenue: number,
   fees: PlatformFees,
   materialBase: number,
-  materialRate: number = ONLINE_MATERIAL_RATE
+  materialRate: number = ONLINE_MATERIAL_RATE,
 ): PlatformProfit {
   const profit =
-    revenue - fees.commissionFee - fees.logisticsFee - fees.adFee;
+    revenue -
+    fees.commissionFee -
+    fees.logisticsFee -
+    fees.inboundShippingFee -
+    fees.adFee;
   const materialCost = Math.round(materialBase * materialRate);
   const netProfit = profit - materialCost;
   return { profit, materialCost, netProfit };
@@ -49,10 +53,12 @@ export function calcPlatformProfit(
  */
 export function calcNaverShippingStats(
   shippingCollected: number,
-  payerCount: number
+  payerCount: number,
 ): ShippingStats {
   const regularCount =
-    NAVER_SHIPPING_FEE > 0 ? Math.round(shippingCollected / NAVER_SHIPPING_FEE) : 0;
+    NAVER_SHIPPING_FEE > 0
+      ? Math.round(shippingCollected / NAVER_SHIPPING_FEE)
+      : 0;
   const freeCount = Math.max(0, payerCount - regularCount);
   const sellerCost =
     freeCount * NAVER_SHIPPING_COST +
@@ -66,7 +72,7 @@ export function calcNaverShippingStats(
 /** 네이버: 순수 상품 매출 (고객 배송비 제외) */
 export function naverMaterialBase(
   revenue: number,
-  shippingCollected: number
+  shippingCollected: number,
 ): number {
   return revenue - shippingCollected;
 }
@@ -74,7 +80,7 @@ export function naverMaterialBase(
 /** 쿠팡: 배송 마크업 제외한 정가 기준 매출 */
 export function coupangMaterialBase(
   revenue: number,
-  totalQuantity: number
+  totalQuantity: number,
 ): number {
   return revenue - totalQuantity * COUPANG_SHIPPING_MARKUP;
 }
@@ -82,7 +88,7 @@ export function coupangMaterialBase(
 /** 고산의낮: 매출(할인가) + 할인분(수수료) = 정가 기준 */
 export function gosanMaterialBase(
   revenue: number,
-  commissionFee: number
+  commissionFee: number,
 ): number {
   return revenue + commissionFee;
 }
@@ -95,7 +101,12 @@ export function calcOfflineVenueProfit(venue: OfflineData): OfflineData {
       : venue.revenue;
   return {
     ...venue,
-    profit: calcPlatformProfit(venue.revenue, venue.fees, matBase, OFFLINE_MATERIAL_RATE),
+    profit: calcPlatformProfit(
+      venue.revenue,
+      venue.fees,
+      matBase,
+      OFFLINE_MATERIAL_RATE,
+    ),
   };
 }
 
@@ -105,30 +116,58 @@ export function calcOverallSummary(
   naver: NaverData,
   coupang: CoupangData,
   offlineVenues: OfflineData[],
-  marketingCost: number = 0
+  marketingCost: number = 0,
 ): OverallSummary {
   const offRevenue = offlineVenues.reduce((s, v) => s + v.revenue, 0);
-  const offCommission = offlineVenues.reduce((s, v) => s + v.fees.commissionFee, 0);
-  const offLogistics = offlineVenues.reduce((s, v) => s + v.fees.logisticsFee, 0);
+  const offCommission = offlineVenues.reduce(
+    (s, v) => s + v.fees.commissionFee,
+    0,
+  );
+  const offLogistics = offlineVenues.reduce(
+    (s, v) => s + v.fees.logisticsFee,
+    0,
+  );
+  const offInbound = offlineVenues.reduce(
+    (s, v) => s + v.fees.inboundShippingFee,
+    0,
+  );
   const offAd = offlineVenues.reduce((s, v) => s + v.fees.adFee, 0);
   const offProfit = offlineVenues.reduce((s, v) => s + v.profit.profit, 0);
-  const offMaterial = offlineVenues.reduce((s, v) => s + v.profit.materialCost, 0);
-  const offNetProfit = offlineVenues.reduce((s, v) => s + v.profit.netProfit, 0);
+  const offMaterial = offlineVenues.reduce(
+    (s, v) => s + v.profit.materialCost,
+    0,
+  );
+  const offNetProfit = offlineVenues.reduce(
+    (s, v) => s + v.profit.netProfit,
+    0,
+  );
   const offTotal = offlineVenues.reduce((s, v) => s + v.totalQuantity, 0);
   const offHandmade = offlineVenues.reduce((s, v) => s + v.handmadeQuantity, 0);
   const offOther = offlineVenues.reduce((s, v) => s + v.otherQuantity, 0);
 
   return {
     totalRevenue: naver.revenue + coupang.revenue + offRevenue,
-    totalCommissionFee: naver.fees.commissionFee + coupang.fees.commissionFee + offCommission,
-    totalLogisticsFee: naver.fees.logisticsFee + coupang.fees.logisticsFee + offLogistics,
+    totalCommissionFee:
+      naver.fees.commissionFee + coupang.fees.commissionFee + offCommission,
+    totalLogisticsFee:
+      naver.fees.logisticsFee + coupang.fees.logisticsFee + offLogistics,
+    totalInboundShippingFee:
+      naver.fees.inboundShippingFee +
+      coupang.fees.inboundShippingFee +
+      offInbound,
     totalAdFee: naver.fees.adFee + coupang.fees.adFee + offAd,
     totalProfit: naver.profit.profit + coupang.profit.profit + offProfit,
-    totalMaterialCost: naver.profit.materialCost + coupang.profit.materialCost + offMaterial,
+    totalMaterialCost:
+      naver.profit.materialCost + coupang.profit.materialCost + offMaterial,
     marketingCost,
-    totalNetProfit: naver.profit.netProfit + coupang.profit.netProfit + offNetProfit - marketingCost,
+    totalNetProfit:
+      naver.profit.netProfit +
+      coupang.profit.netProfit +
+      offNetProfit -
+      marketingCost,
     totalQuantity: naver.totalQuantity + coupang.totalQuantity + offTotal,
-    handmadeQuantity: naver.handmadeQuantity + coupang.handmadeQuantity + offHandmade,
+    handmadeQuantity:
+      naver.handmadeQuantity + coupang.handmadeQuantity + offHandmade,
     otherQuantity: naver.otherQuantity + coupang.otherQuantity + offOther,
   };
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,6 +8,7 @@ import type { PlatformFees, SponsorshipData } from "@/lib/types";
 export const EMPTY_FEES: PlatformFees = {
   settlementAmount: 0,
   logisticsFee: 0,
+  inboundShippingFee: 0,
   commissionFee: 0,
   adFee: 0,
 };

--- a/src/lib/naver-api/collect.ts
+++ b/src/lib/naver-api/collect.ts
@@ -22,28 +22,31 @@ import { getSettlements } from "./settlement";
  */
 export async function collectNaverDataViaApi(
   startDate: string,
-  endDate: string
+  endDate: string,
 ): Promise<{ data: NaverData; warnings: ScrapeWarning[] }> {
   const warnings: ScrapeWarning[] = [];
 
   // ─── 1. 주문 데이터 ────────────────────────────────────────────────
-  let allOrders = await getOrders(startDate, endDate);
+  const allOrders = await getOrders(startDate, endDate);
   const validOrders = filterValidOrders(allOrders);
 
   // 매출: 유효 주문의 totalPaymentAmount 합산
-  const revenue = validOrders.reduce(
-    (sum, o) => sum + o.totalPaymentAmount, 0
-  );
+  const revenue = validOrders.reduce((sum, o) => sum + o.totalPaymentAmount, 0);
 
   // 배송비: 주문(orderId) 단위로 중복 제거 후 합산
   // (한 주문에 상품 여러 개면 deliveryFeeAmount가 중복될 수 있음)
   const orderShippingMap = new Map<string, number>();
   for (const order of validOrders) {
     const current = orderShippingMap.get(order.orderId) ?? 0;
-    orderShippingMap.set(order.orderId, Math.max(current, order.deliveryFeeAmount));
+    orderShippingMap.set(
+      order.orderId,
+      Math.max(current, order.deliveryFeeAmount),
+    );
   }
-  const shippingCollected = Array.from(orderShippingMap.values())
-    .reduce((sum, fee) => sum + fee, 0);
+  const shippingCollected = Array.from(orderShippingMap.values()).reduce(
+    (sum, fee) => sum + fee,
+    0,
+  );
   const payerCount = orderShippingMap.size;
 
   // 제품별 판매수량 집계
@@ -75,12 +78,10 @@ export async function collectNaverDataViaApi(
 
   try {
     const settlements = await getSettlements(startDate, endDate);
-    settlementAmount = settlements.reduce(
-      (sum, s) => sum + s.settleAmount, 0
-    );
+    settlementAmount = settlements.reduce((sum, s) => sum + s.settleAmount, 0);
     // commissionSettleAmount는 음수일 수 있으므로 절대값 사용
     commissionFee = Math.abs(
-      settlements.reduce((sum, s) => sum + s.commissionSettleAmount, 0)
+      settlements.reduce((sum, s) => sum + s.commissionSettleAmount, 0),
     );
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
@@ -95,6 +96,7 @@ export async function collectNaverDataViaApi(
   const fees: PlatformFees = {
     commissionFee,
     logisticsFee: shippingStats.sellerCost,
+    inboundShippingFee: 0,
     adFee: 0,
     settlementAmount,
   };
@@ -110,7 +112,9 @@ export async function collectNaverDataViaApi(
       fees,
       shippingStats,
       profit: calcPlatformProfit(
-        revenue, fees, naverMaterialBase(revenue, shippingCollected)
+        revenue,
+        fees,
+        naverMaterialBase(revenue, shippingCollected),
       ),
       products,
     },
@@ -123,7 +127,7 @@ export async function collectNaverDataViaApi(
 /** 비즈 식물 상품은 옵션별로 분리 집계, 나머지는 상품명 그대로 */
 function resolveProductKey(
   productName: string,
-  productOption?: string
+  productOption?: string,
 ): string {
   if (!productOption) return productName;
   if (productName.includes("비즈 식물") || productName.includes("비즈식물")) {

--- a/src/lib/scrapers/index.ts
+++ b/src/lib/scrapers/index.ts
@@ -58,7 +58,7 @@ async function createBrowserPage(storageStatePath?: string | null): Promise<{
  */
 export function getDateRange(
   year: number,
-  month: number
+  month: number,
 ): { start: string; end: string } {
   const today = new Date();
   const isCurrentMonth =
@@ -81,7 +81,7 @@ export function getDateRange(
  */
 async function collectNaverData(
   year: number,
-  month: number
+  month: number,
 ): Promise<{ data: NaverData; warnings: ScrapeWarning[] }> {
   const { start, end } = getDateRange(year, month);
   return collectNaverDataViaApi(start, end);
@@ -94,7 +94,7 @@ async function collectNaverData(
  */
 async function collectCoupangData(
   year: number,
-  month: number
+  month: number,
 ): Promise<{ data: CoupangData; warnings: ScrapeWarning[] }> {
   const { start, end } = getDateRange(year, month);
   const warnings: ScrapeWarning[] = [];
@@ -128,7 +128,7 @@ async function collectCoupangData(
     const settlementAttempt = await withRetry(
       "coupang-settlement",
       () => scrapeCoupangSettlement(page, year, month),
-      null
+      null,
     );
     if (settlementAttempt.failed) {
       warnings.push({
@@ -155,6 +155,7 @@ async function collectCoupangData(
   const fees: PlatformFees = {
     commissionFee,
     logisticsFee,
+    inboundShippingFee: 0,
     adFee,
     settlementAmount: 0,
   };
@@ -172,7 +173,9 @@ async function collectCoupangData(
       otherQuantity: totalQuantity - handmadeQuantity,
       fees,
       profit: calcPlatformProfit(
-        revenue, fees, coupangMaterialBase(revenue, totalQuantity)
+        revenue,
+        fees,
+        coupangMaterialBase(revenue, totalQuantity),
       ),
       products,
     },
@@ -188,7 +191,7 @@ async function collectCoupangData(
  */
 export async function collectMonthlyData(
   year: number,
-  month: number
+  month: number,
 ): Promise<{
   naver: NaverData;
   coupang: CoupangData;
@@ -204,33 +207,38 @@ export async function collectMonthlyData(
   ]);
 
   // 재시도 실패 경고 합산
-  const scraperWarnings = [
-    ...naverResult.warnings,
-    ...coupangResult.warnings,
-  ];
+  const scraperWarnings = [...naverResult.warnings, ...coupangResult.warnings];
 
   // 이미 실패 보고된 수집기는 정합성 검증에서 중복 경고 방지
   const failedScrapers = new Set<string>();
   for (const w of scraperWarnings) {
     if (w.level === "error") {
       // 네이버 API 실패 시 관련 검증 규칙 건너뜀
-      if (w.message.includes("네이버 정산 API")) failedScrapers.add("naver-settlement");
-      if (w.message.includes("네이버 주문 API") || w.message.includes("네이버 API")) {
+      if (w.message.includes("네이버 정산 API"))
+        failedScrapers.add("naver-settlement");
+      if (
+        w.message.includes("네이버 주문 API") ||
+        w.message.includes("네이버 API")
+      ) {
         failedScrapers.add("naver-orders");
         failedScrapers.add("naver-sales");
       }
       // 쿠팡 실패
-      if (w.message.includes("쿠팡 주문 API") || w.message.includes("쿠팡 판매분석")) {
+      if (
+        w.message.includes("쿠팡 주문 API") ||
+        w.message.includes("쿠팡 판매분석")
+      ) {
         failedScrapers.add("coupang-orders");
       }
-      if (w.message.includes("쿠팡 정산")) failedScrapers.add("coupang-settlement");
+      if (w.message.includes("쿠팡 정산"))
+        failedScrapers.add("coupang-settlement");
     }
   }
 
   const validationWarnings = validateCollectedData(
     naverResult.data,
     coupangResult.data,
-    failedScrapers
+    failedScrapers,
   );
 
   return {

--- a/src/lib/storage/report-store.ts
+++ b/src/lib/storage/report-store.ts
@@ -35,7 +35,13 @@ const writeLocks = new Map<string, Promise<void>>();
 function withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
   const prev = writeLocks.get(key) ?? Promise.resolve();
   const next = prev.then(fn, fn);
-  writeLocks.set(key, next.then(() => {}, () => {}));
+  writeLocks.set(
+    key,
+    next.then(
+      () => {},
+      () => {},
+    ),
+  );
   return next;
 }
 
@@ -43,7 +49,11 @@ function getReportPath(year: number, month: number): string {
   return path.join(DATA_DIR, `${year}-${pad(month)}.json`);
 }
 
-function getVersionPath(year: number, month: number, timestamp: number): string {
+function getVersionPath(
+  year: number,
+  month: number,
+  timestamp: number,
+): string {
   return path.join(DATA_DIR, `${year}-${pad(month)}.v${timestamp}.json`);
 }
 
@@ -64,7 +74,10 @@ async function deleteOldVersions(year: number, month: number): Promise<void> {
 }
 
 /** 현재 레포트를 타임스탬프 백업 파일로 복사 */
-async function createBackup(year: number, month: number): Promise<number | null> {
+async function createBackup(
+  year: number,
+  month: number,
+): Promise<number | null> {
   const filePath = getReportPath(year, month);
   try {
     await fs.access(filePath);
@@ -82,7 +95,7 @@ async function createBackup(year: number, month: number): Promise<number | null>
 /** 특정 월의 백업 버전 목록 (최신순) */
 export async function listVersions(
   year: number,
-  month: number
+  month: number,
 ): Promise<{ timestamp: number; date: string; size: number }[]> {
   await ensureDataDir();
   const prefix = `${year}-${pad(month)}.v`;
@@ -95,7 +108,11 @@ export async function listVersions(
     if (!match) continue;
     const ts = parseInt(match[3]);
     const stat = await fs.stat(path.join(DATA_DIR, f));
-    versions.push({ timestamp: ts, date: new Date(ts).toISOString(), size: stat.size });
+    versions.push({
+      timestamp: ts,
+      date: new Date(ts).toISOString(),
+      size: stat.size,
+    });
   }
 
   return versions.sort((a, b) => b.timestamp - a.timestamp);
@@ -105,7 +122,7 @@ export async function listVersions(
 export async function restoreVersion(
   year: number,
   month: number,
-  timestamp: number
+  timestamp: number,
 ): Promise<MonthlyReport> {
   const filePath = getReportPath(year, month);
   const versionPath = getVersionPath(year, month, timestamp);
@@ -156,15 +173,29 @@ function migrateReport(raw: Record<string, unknown>): MonthlyReport {
     if (naver.shippingCollected === undefined) naver.shippingCollected = 0;
     if (naver.payerCount === undefined) naver.payerCount = 0;
   }
+  // PlatformFees에 inboundShippingFee 없는 기존 레포트 호환
+  ensureInboundShippingFee(raw.naver);
+  ensureInboundShippingFee(raw.coupang);
+  if (Array.isArray(raw.offline)) {
+    for (const venue of raw.offline) ensureInboundShippingFee(venue);
+  }
   // warnings 필드 없는 기존 레포트 호환
   if (!raw.warnings) raw.warnings = [];
   return raw as unknown as MonthlyReport;
 }
 
+function ensureInboundShippingFee(node: unknown): void {
+  if (!node || typeof node !== "object") return;
+  const fees = (node as { fees?: Record<string, unknown> }).fees;
+  if (fees && fees.inboundShippingFee === undefined) {
+    fees.inboundShippingFee = 0;
+  }
+}
+
 /** 레포트 로드. 없으면 null 반환 */
 export async function loadReport(
   year: number,
-  month: number
+  month: number,
 ): Promise<MonthlyReport | null> {
   const filePath = getReportPath(year, month);
   try {
@@ -178,7 +209,6 @@ export async function loadReport(
 
 // ─── updateReport 서브 함수 ────────────────────────────────────────────────
 
-
 /** 오프라인 입점처 배열에 추가/삭제/수정 반영 */
 function applyOfflineUpdates(
   existing: OfflineData[],
@@ -187,7 +217,7 @@ function applyOfflineUpdates(
     offlineVenueId?: string;
     addOfflineVenue?: { id: string; name: string };
     removeOfflineVenueId?: string;
-  }
+  },
 ): OfflineData[] {
   let venues = [...existing];
 
@@ -201,7 +231,13 @@ function applyOfflineUpdates(
         totalQuantity: 0,
         handmadeQuantity: 0,
         otherQuantity: 0,
-        fees: { commissionFee: 0, logisticsFee: 0, adFee: 0, settlementAmount: 0 },
+        fees: {
+          commissionFee: 0,
+          logisticsFee: 0,
+          inboundShippingFee: 0,
+          adFee: 0,
+          settlementAmount: 0,
+        },
         profit: { profit: 0, materialCost: 0, netProfit: 0 },
         products: [],
       });
@@ -217,7 +253,9 @@ function applyOfflineUpdates(
       if (venue.venueId !== updates.offlineVenueId) return venue;
       const merged = deepMerge(venue, updates.offline!);
       if (updates.offline!.products !== undefined) {
-        const { products, ...qtySummary } = reclassifyAndSummarize(merged.products);
+        const { products, ...qtySummary } = reclassifyAndSummarize(
+          merged.products,
+        );
         return { ...merged, products, ...qtySummary };
       }
       return merged;
@@ -231,7 +269,7 @@ function applyOfflineUpdates(
 function recalcPlatformProfits(
   naver: NaverData,
   coupang: CoupangData,
-  offlineVenues: OfflineData[]
+  offlineVenues: OfflineData[],
 ): { naver: NaverData; coupang: CoupangData; offline: OfflineData[] } {
   const naverReclassified = reclassifyAndSummarize(naver.products);
   const coupangReclassified = reclassifyAndSummarize(coupang.products);
@@ -243,9 +281,13 @@ function recalcPlatformProfits(
 
   const naverShippingStats = calcNaverShippingStats(
     naver.shippingCollected ?? 0,
-    naver.payerCount ?? 0
+    naver.payerCount ?? 0,
   );
-  const naverFees = { ...naver.fees, logisticsFee: naverShippingStats.sellerCost, adFee: 0 };
+  const naverFees = {
+    ...naver.fees,
+    logisticsFee: naverShippingStats.sellerCost,
+    adFee: 0,
+  };
   const naverWithProfit: NaverData = {
     ...naver,
     fees: naverFees,
@@ -255,8 +297,9 @@ function recalcPlatformProfits(
     handmadeQuantity: naverReclassified.handmadeQuantity,
     otherQuantity: naverReclassified.otherQuantity,
     profit: calcPlatformProfit(
-      naver.revenue, naverFees,
-      naverMaterialBase(naver.revenue, naver.shippingCollected ?? 0)
+      naver.revenue,
+      naverFees,
+      naverMaterialBase(naver.revenue, naver.shippingCollected ?? 0),
     ),
   };
 
@@ -268,18 +311,23 @@ function recalcPlatformProfits(
     handmadeQuantity: coupangReclassified.handmadeQuantity,
     otherQuantity: coupangReclassified.otherQuantity,
     profit: calcPlatformProfit(
-      coupang.revenue, coupang.fees,
-      coupangMaterialBase(coupang.revenue, coupangTotalQty)
+      coupang.revenue,
+      coupang.fees,
+      coupangMaterialBase(coupang.revenue, coupangTotalQty),
     ),
   };
 
-  return { naver: naverWithProfit, coupang: coupangWithProfit, offline: offlineWithProfit };
+  return {
+    naver: naverWithProfit,
+    coupang: coupangWithProfit,
+    offline: offlineWithProfit,
+  };
 }
 
 /** 협찬 데이터 병합 + 수량/비용 자동 재계산 */
 function mergeSponsorshipData(
   existing: SponsorshipData | undefined,
-  patch: DeepPartial<SponsorshipData> | undefined
+  patch: DeepPartial<SponsorshipData> | undefined,
 ): SponsorshipData {
   const base = existing ?? DEFAULT_SPONSORSHIP;
   const merged = patch ? deepMerge(base, patch) : base;
@@ -318,28 +366,41 @@ export async function updateReport(
     removeOfflineVenueId?: string;
     sponsorship?: DeepPartial<SponsorshipData>;
     insights?: MonthlyReport["insights"];
-  }
+  },
 ): Promise<MonthlyReport> {
   const existing = await loadReport(year, month);
   if (!existing) {
-    throw new Error(`${year}년 ${month}월 레포트가 없습니다. 먼저 수집을 실행해주세요.`);
+    throw new Error(
+      `${year}년 ${month}월 레포트가 없습니다. 먼저 수집을 실행해주세요.`,
+    );
   }
 
   // 1) 플랫폼 데이터 병합
-  const naver = updates.naver ? deepMerge(existing.naver, updates.naver) : existing.naver;
-  const coupang = updates.coupang ? deepMerge(existing.coupang, updates.coupang) : existing.coupang;
+  const naver = updates.naver
+    ? deepMerge(existing.naver, updates.naver)
+    : existing.naver;
+  const coupang = updates.coupang
+    ? deepMerge(existing.coupang, updates.coupang)
+    : existing.coupang;
   const offlineVenues = applyOfflineUpdates(existing.offline, updates);
 
   // 2) 카테고리 재분류 + 이익 재계산
   const platforms = recalcPlatformProfits(naver, coupang, offlineVenues);
 
   // 3) 협찬 데이터 병합
-  const sponsorship = mergeSponsorshipData(existing.sponsorship, updates.sponsorship);
+  const sponsorship = mergeSponsorshipData(
+    existing.sponsorship,
+    updates.sponsorship,
+  );
 
   // 4) 파생 필드 재계산 (summary·ranking·matrix)
   const mapping = await loadProductMapping();
   const derived = rebuildDerivedFields(
-    platforms.naver, platforms.coupang, platforms.offline, sponsorship, mapping
+    platforms.naver,
+    platforms.coupang,
+    platforms.offline,
+    sponsorship,
+    mapping,
   );
 
   const now = new Date().toISOString();
@@ -349,9 +410,7 @@ export async function updateReport(
     sponsorship,
     ...derived,
     insights: updates.insights ?? existing.insights,
-    insightsGeneratedAt: updates.insights
-      ? now
-      : existing.insightsGeneratedAt,
+    insightsGeneratedAt: updates.insights ? now : existing.insightsGeneratedAt,
     lastModifiedAt: now,
   };
 
@@ -371,16 +430,14 @@ export async function listReports(): Promise<
       const [y, m] = f.replace(".json", "").split("-").map(Number);
       return { year: y, month: m };
     })
-    .sort((a, b) =>
-      a.year !== b.year ? b.year - a.year : b.month - a.month
-    );
+    .sort((a, b) => (a.year !== b.year ? b.year - a.year : b.month - a.month));
 }
 
 /** 최근 N개월 히스토리 로드 (인사이트 생성용) — [전달, 전전달, ...] 순 */
 export async function loadRecentHistory(
   year: number,
   month: number,
-  count: number
+  count: number,
 ): Promise<(MonthlyReport | null)[]> {
   const results: (MonthlyReport | null)[] = [];
   let y = year,
@@ -393,4 +450,3 @@ export async function loadRecentHistory(
   }
   return results;
 }
-

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -20,6 +20,7 @@ export interface ProductSales {
 export interface PlatformFees {
   commissionFee: number; // 플랫폼 수수료
   logisticsFee: number; // 물류비 (네이버: 판매자부담 배송비 / 쿠팡: 풀필먼트비용)
+  inboundShippingFee: number; // 입고 배송비 (쿠팡: 풀필먼트 입고 시 셀러 부담 택배비, 수기 / 그 외: 0)
   adFee: number; // 광고비 (쿠팡: 자동 / 오프라인: 수기 / 네이버: 미사용=0)
   settlementAmount: number; // 정산금 (참고용 — 네이버: 자동, 쿠팡: 0, 오프라인: 수기)
 }
@@ -58,14 +59,14 @@ export interface CoupangData {
 
 // ─── 오프라인 입점처 정보 (레지스트리) ────────────────────────────────────
 export interface VenueInfo {
-  id: string;        // slug 기반 고유 ID (예: "gosan")
-  name: string;      // 입점처명 (예: "고산의낮")
-  createdAt: string;  // ISO 8601
+  id: string; // slug 기반 고유 ID (예: "gosan")
+  name: string; // 입점처명 (예: "고산의낮")
+  createdAt: string; // ISO 8601
 }
 
 // ─── 오프라인 입점처 데이터 — 전체 수기 입력 ─────────────────────────────
 export interface OfflineData {
-  venueId: string;   // 입점처 레지스트리 ID 참조
+  venueId: string; // 입점처 레지스트리 ID 참조
   venueName: string; // 입점처명 (기본값: "고산의낮")
   revenue: number;
   totalQuantity: number;
@@ -81,10 +82,11 @@ export interface OverallSummary {
   totalRevenue: number;
   totalCommissionFee: number;
   totalLogisticsFee: number;
+  totalInboundShippingFee: number;
   totalAdFee: number;
   totalProfit: number;
   totalMaterialCost: number;
-  marketingCost: number;    // 협찬 마케팅 비용 (totalNetProfit에서 차감됨)
+  marketingCost: number; // 협찬 마케팅 비용 (totalNetProfit에서 차감됨)
   totalNetProfit: number;
   // 판매량
   totalQuantity: number;
@@ -117,18 +119,18 @@ export interface ProductMatrixRow {
 
 /** 협찬 제공 상품 1건 */
 export interface SponsoredItem {
-  productName: string;       // canonical 상품명 (productMatrix 기준)
+  productName: string; // canonical 상품명 (productMatrix 기준)
   category: ProductCategory;
   quantity: number;
-  unitPrice?: number;        // 협찬 단가 (원) — 있으면 marketingCost 자동 계산
+  unitPrice?: number; // 협찬 단가 (원) — 있으면 marketingCost 자동 계산
 }
 
 /** 협찬 마케팅 전체 데이터 (수기 입력) */
 export interface SponsorshipData {
-  items: SponsoredItem[];        // 협찬 제공 상품 목록
-  marketingCost: number;         // 마케팅 비용 (순이익에서 차감)
-  totalQuantity: number;         // 총 협찬 제공 수량 (자동 계산)
-  handmadeQuantity: number;      // 끈갈피 협찬 제공 수량 (자동 계산)
+  items: SponsoredItem[]; // 협찬 제공 상품 목록
+  marketingCost: number; // 마케팅 비용 (순이익에서 차감)
+  totalQuantity: number; // 총 협찬 제공 수량 (자동 계산)
+  handmadeQuantity: number; // 끈갈피 협찬 제공 수량 (자동 계산)
 }
 
 // ─── 상품 매핑 (네이버↔쿠팡 상품명 연결) ─────────────────────────────────
@@ -147,13 +149,13 @@ export interface ProductMappingConfig {
 // ─── Claude AI 인사이트 ───────────────────────────────────────────────────
 
 export type InsightCategory =
-  | "revenue"       // 매출 동향
-  | "profit"        // 이익률/비용 구조
-  | "product"       // 상품 전략
-  | "platform"      // 플랫폼 비교
-  | "ad"            // 광고 효율
-  | "sponsorship"   // 협찬 마케팅 효과
-  | "trend";        // 전달 대비 추세
+  | "revenue" // 매출 동향
+  | "profit" // 이익률/비용 구조
+  | "product" // 상품 전략
+  | "platform" // 플랫폼 비교
+  | "ad" // 광고 효율
+  | "sponsorship" // 협찬 마케팅 효과
+  | "trend"; // 전달 대비 추세
 
 export interface SalesInsight {
   title: string;
@@ -167,25 +169,25 @@ export interface SalesInsight {
 /** 전체 인사이트 뷰에서 사용하는 월별 집계 데이터 (차트 X축 단위) */
 export interface MonthlyOverview {
   period: { year: number; month: number };
-  label: string;              // "2025.12" — 차트 X축 레이블
+  label: string; // "2025.12" — 차트 X축 레이블
   totalRevenue: number;
   totalNetProfit: number;
   totalQuantity: number;
   handmadeQuantity: number;
   otherQuantity: number;
-  marginRate: number;         // 소수점 1자리 % (서버에서 미리 계산)
+  marginRate: number; // 소수점 1자리 % (서버에서 미리 계산)
   naverRevenue: number;
   coupangRevenue: number;
   offlineRevenue: number;
   // 마케팅 비용
   naverAdFee: number;
   coupangAdFee: number;
-  sponsorshipCost: number;    // 협찬 마케팅 비용 (부자재비)
+  sponsorshipCost: number; // 협찬 마케팅 비용 (부자재비)
 }
 
 /** GET /api/overview 응답 타입 */
 export interface OverviewResponse {
-  months: MonthlyOverview[];  // 오름차순 정렬 (차트 X축 좌→우)
+  months: MonthlyOverview[]; // 오름차순 정렬 (차트 X축 좌→우)
   totals: {
     totalQuantity: number;
     handmadeQuantity: number;
@@ -214,18 +216,18 @@ export interface MonthlyReport {
   naver: NaverData;
   coupang: CoupangData;
   offline: OfflineData[];
-  sponsorship: SponsorshipData;       // 협찬 마케팅 데이터 (수기 입력)
+  sponsorship: SponsorshipData; // 협찬 마케팅 데이터 (수기 입력)
   summary: OverallSummary;
   // 랭킹
-  naverRanking: ProductRankEntry[];           // 네이버 TOP3
-  coupangRanking: ProductRankEntry[];         // 쿠팡 TOP3
-  offlineRanking: ProductRankEntry[];         // 오프라인 TOP3
-  overallRanking: ProductRankEntry[];         // 전체 통합 TOP5
+  naverRanking: ProductRankEntry[]; // 네이버 TOP3
+  coupangRanking: ProductRankEntry[]; // 쿠팡 TOP3
+  offlineRanking: ProductRankEntry[]; // 오프라인 TOP3
+  overallRanking: ProductRankEntry[]; // 전체 통합 TOP5
   sponsorExcludedRanking: ProductRankEntry[]; // 협찬 제외 TOP5
   productMatrix: ProductMatrixRow[]; // 상품 × 플랫폼 표
   insights: SalesInsight[];
   insightsGeneratedAt?: string; // ISO 8601 — 인사이트가 마지막으로 생성된 시각
-  warnings: ScrapeWarning[];  // 수집 시 경고
+  warnings: ScrapeWarning[]; // 수집 시 경고
   collectedAt: string; // ISO 8601
   lastModifiedAt: string; // ISO 8601
 }


### PR DESCRIPTION
## Summary
- 네이버 커머스 API · 쿠팡 RG Order API로 스크레이퍼 교체 (Playwright 의존도 축소)
- 협찬 마케팅 비용 자동 계산 (단가 × 수량) 및 카드 UI · AI 인사이트 연동
- 쿠팡 카드에 입고 배송비 수기 입력 항목 추가, 이익 계산에 반영
- 월별 순수익 그래프, 비즈 식물 옵션별 집계, 고산의낮 계산 툴팁
- 네이버 정산/배송비, 쿠팡 정산-주문 날짜 기준 등 다수 버그 수정

## 주요 변경
- **API 마이그레이션**: 네이버 커머스 API, 쿠팡 RG Order API 모듈 추가 후 스크레이퍼 교체
- **협찬 자동 계산**: items 저장 시 marketingCost 자동 산출, AI 인사이트 단가 정보 포함
- **쿠팡 입고 배송비**: PlatformFees에 inboundShippingFee 필드, 수기 입력, 마이그레이션 포함
- **insights**: 월별 순수익 라인 차트, 비즈 식물 옵션별 분리

## Test plan
- [x] `npx vitest run` — 141/141 통과
- [x] `npx tsc --noEmit` — 타입 오류 없음
- [x] 쿠팡 카드 입고 배송비 입력 시 이익 차감 동작 확인
- [x] 입고 배송비 EditRow 정렬 (Row와 우측 끝 일치) 확인
- [x] 기존 레포트 마이그레이션 (inboundShippingFee 누락) 동작 확인