### PR TITLE
fix: 협찬 비용 공식을 매출 환불 기반으로 단순화

### DIFF
--- a/scripts/migrate-sponsorship-cost.ts
+++ b/scripts/migrate-sponsorship-cost.ts
@@ -1,0 +1,54 @@
+/**
+ * 협찬 비용 공식 변경(#12)에 따른 기존 레포트 일괄 재계산 스크립트.
+ *
+ * 사용법: tsx scripts/migrate-sponsorship-cost.ts
+ *
+ * 동작:
+ * - listReports로 모든 저장된 (year, month) 조회
+ * - 각 레포트를 loadReport → sponsorship.items 단가가 모두 입력된 경우에만
+ *   updateReport({ sponsorship: { items: 기존 items } })를 호출하여 자동 재계산.
+ * - 단가가 누락된 월은 수기 입력값을 보존하기 위해 건너뛰고 로그만 남김.
+ */
+import {
+  listReports,
+  loadReport,
+  updateReport,
+} from "@/lib/storage/report-store";
+
+async function main() {
+  const reports = await listReports();
+  const results: { year: number; month: number; status: string }[] = [];
+
+  for (const { year, month } of reports) {
+    const existing = await loadReport(year, month);
+    if (!existing) {
+      results.push({ year, month, status: "skip: not found" });
+      continue;
+    }
+
+    const items = existing.sponsorship?.items ?? [];
+    if (items.length === 0) {
+      results.push({ year, month, status: "skip: no items" });
+      continue;
+    }
+
+    const allHaveUnitPrice = items.every(
+      (i) => i.unitPrice != null && i.unitPrice > 0,
+    );
+    if (!allHaveUnitPrice) {
+      results.push({ year, month, status: "skip: missing unitPrice" });
+      continue;
+    }
+
+    // items 그대로 다시 넘기면 mergeSponsorshipData가 새 공식으로 marketingCost 재계산
+    await updateReport(year, month, { sponsorship: { items } });
+    results.push({ year, month, status: "migrated" });
+  }
+
+  console.table(results);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/dashboard/SponsorshipCard.tsx
+++ b/src/components/dashboard/SponsorshipCard.tsx
@@ -12,7 +12,11 @@ interface Props {
   onUpdate: (patch: object) => Promise<void>;
 }
 
-export default function SponsorshipCard({ sponsorship, productMatrix, onUpdate }: Props) {
+export default function SponsorshipCard({
+  sponsorship,
+  productMatrix,
+  onUpdate,
+}: Props) {
   const hasUnitPrices =
     sponsorship.items.length > 0 &&
     sponsorship.items.every((i) => i.unitPrice != null && i.unitPrice > 0);
@@ -21,7 +25,7 @@ export default function SponsorshipCard({ sponsorship, productMatrix, onUpdate }
     async (items: SponsoredItem[]) => {
       await onUpdate({ sponsorship: { items } });
     },
-    [onUpdate]
+    [onUpdate],
   );
 
   return (
@@ -55,18 +59,21 @@ export default function SponsorshipCard({ sponsorship, productMatrix, onUpdate }
 
         {sponsorship.marketingCost > 0 && (
           <p className="text-xs text-gray-400 mt-1 mb-3">
-            순이익에서 {sponsorship.marketingCost.toLocaleString("ko-KR")}원 차감됩니다.
+            순이익에서 {sponsorship.marketingCost.toLocaleString("ko-KR")}원
+            차감됩니다.
           </p>
         )}
 
         {/* 계산식 툴팁 */}
         <div className="bg-warm-50 rounded-lg px-3 py-2.5 mb-1">
           <p className="text-xs text-gray-600 leading-relaxed">
-            <span className="font-medium">광고비 계산:</span>{" "}
-            (단가 + 배송비 3,000) × (VAT 10% + 수수료 2.857%) + 실배송비 3,300
+            <span className="font-medium">협찬 비용 계산:</span> (단가 + 배송비
+            3,000) × 1.1 (VAT 포함)
           </p>
           <p className="text-xs text-gray-400 mt-1">
-            재료비는 플랫폼 매출 정산에서 이미 차감되므로 포함하지 않습니다.
+            매출에 잡힌 협찬 분을 순이익에서 환불 처리합니다. 정산
+            수수료·부자재비·배송비 차액은 자동 계산에서 별도 차감되어 중복되지
+            않습니다.
           </p>
         </div>
 

--- a/src/lib/calculations/sponsorship.test.ts
+++ b/src/lib/calculations/sponsorship.test.ts
@@ -1,27 +1,28 @@
 import { describe, test, expect } from "vitest";
-import { calcUnitSponsorshipCost, calcTotalSponsorshipCost } from "./sponsorship";
+import {
+  calcUnitSponsorshipCost,
+  calcTotalSponsorshipCost,
+} from "./sponsorship";
 
 // 기본 상수 기준:
-// MARKETING_LINK_FEE_RATE = 0.02857
-// SPONSOR_SHIPPING_FEE    = 3000
-// SPONSOR_SHIPPING_COST   = 3300
+// SPONSOR_SHIPPING_FEE = 3000
 //
-// 공식: round((단가 + 3000) * (0.1 + 0.02857) + 3300)
+// 공식: round((단가 + 3000) * 1.1)
 
 describe("calcUnitSponsorshipCost", () => {
-  // (13900 + 3000) * 0.12857 + 3300 = 16900 * 0.12857 + 3300 = 2172.83 + 3300 = 5472.83 → 5473
+  // (13900 + 3000) * 1.1 = 16900 * 1.1 = 18590
   test("13,900원 제품의 1개당 비용을 계산한다", () => {
-    expect(calcUnitSponsorshipCost(13900)).toBe(5473);
+    expect(calcUnitSponsorshipCost(13900)).toBe(18590);
   });
 
-  // (23000 + 3000) * 0.12857 + 3300 = 26000 * 0.12857 + 3300 = 3342.82 + 3300 = 6642.82 → 6643
+  // (23000 + 3000) * 1.1 = 26000 * 1.1 = 28600
   test("23,000원 제품의 1개당 비용을 계산한다", () => {
-    expect(calcUnitSponsorshipCost(23000)).toBe(6643);
+    expect(calcUnitSponsorshipCost(23000)).toBe(28600);
   });
 
-  // (0 + 3000) * 0.12857 + 3300 = 385.71 + 3300 = 3685.71 → 3686
-  test("단가 0원이면 배송비+수수료만 남는다", () => {
-    expect(calcUnitSponsorshipCost(0)).toBe(3686);
+  // (0 + 3000) * 1.1 = 3300
+  test("단가 0원이면 배송비분만 남는다", () => {
+    expect(calcUnitSponsorshipCost(0)).toBe(3300);
   });
 
   test("결과는 원 단위 정수다", () => {
@@ -35,34 +36,59 @@ describe("calcTotalSponsorshipCost", () => {
     expect(calcTotalSponsorshipCost([])).toBe(0);
   });
 
-  // 5473 * 8 = 43784
+  // 18590 * 8 = 148720
   test("단일 아이템의 총 비용을 계산한다", () => {
     const items = [
-      { productName: "끈갈피A", category: "handmade" as const, quantity: 8, unitPrice: 13900 },
+      {
+        productName: "끈갈피A",
+        category: "handmade" as const,
+        quantity: 8,
+        unitPrice: 13900,
+      },
     ];
-    expect(calcTotalSponsorshipCost(items)).toBe(5473 * 8);
+    expect(calcTotalSponsorshipCost(items)).toBe(18590 * 8);
   });
 
-  // 6643 * 3 = 19929
-  test("수량이 3개인 23,000원 제품의 총 비용은 약 19,929원이다", () => {
+  // 28600 * 3 = 85800
+  test("수량이 3개인 23,000원 제품의 총 비용은 85,800원이다", () => {
     const items = [
-      { productName: "끈갈피A", category: "handmade" as const, quantity: 3, unitPrice: 23000 },
+      {
+        productName: "끈갈피A",
+        category: "handmade" as const,
+        quantity: 3,
+        unitPrice: 23000,
+      },
     ];
-    expect(calcTotalSponsorshipCost(items)).toBe(6643 * 3);
+    expect(calcTotalSponsorshipCost(items)).toBe(28600 * 3);
   });
 
-  // 6643*3 + 5473*2 = 19929 + 10946 = 30875
+  // 28600*3 + 18590*2 = 85800 + 37180 = 122980
   test("여러 아이템의 총 비용을 합산한다", () => {
     const items = [
-      { productName: "끈갈피A", category: "handmade" as const, quantity: 3, unitPrice: 23000 },
-      { productName: "끈갈피B", category: "handmade" as const, quantity: 2, unitPrice: 13900 },
+      {
+        productName: "끈갈피A",
+        category: "handmade" as const,
+        quantity: 3,
+        unitPrice: 23000,
+      },
+      {
+        productName: "끈갈피B",
+        category: "handmade" as const,
+        quantity: 2,
+        unitPrice: 13900,
+      },
     ];
-    expect(calcTotalSponsorshipCost(items)).toBe(6643 * 3 + 5473 * 2);
+    expect(calcTotalSponsorshipCost(items)).toBe(28600 * 3 + 18590 * 2);
   });
 
   test("unitPrice가 없는 아이템이 있으면 null을 반환한다", () => {
     const items = [
-      { productName: "끈갈피A", category: "handmade" as const, quantity: 3, unitPrice: 23000 },
+      {
+        productName: "끈갈피A",
+        category: "handmade" as const,
+        quantity: 3,
+        unitPrice: 23000,
+      },
       { productName: "끈갈피B", category: "handmade" as const, quantity: 2 },
     ];
     expect(calcTotalSponsorshipCost(items)).toBeNull();
@@ -70,15 +96,25 @@ describe("calcTotalSponsorshipCost", () => {
 
   test("unitPrice가 0인 아이템이 있으면 null을 반환한다", () => {
     const items = [
-      { productName: "끈갈피A", category: "handmade" as const, quantity: 3, unitPrice: 0 },
+      {
+        productName: "끈갈피A",
+        category: "handmade" as const,
+        quantity: 3,
+        unitPrice: 0,
+      },
     ];
     expect(calcTotalSponsorshipCost(items)).toBeNull();
   });
 
   test("수량이 1인 단일 아이템도 정확히 계산한다", () => {
     const items = [
-      { productName: "끈갈피A", category: "handmade" as const, quantity: 1, unitPrice: 13900 },
+      {
+        productName: "끈갈피A",
+        category: "handmade" as const,
+        quantity: 1,
+        unitPrice: 13900,
+      },
     ];
-    expect(calcTotalSponsorshipCost(items)).toBe(5473);
+    expect(calcTotalSponsorshipCost(items)).toBe(18590);
   });
 });

--- a/src/lib/calculations/sponsorship.ts
+++ b/src/lib/calculations/sponsorship.ts
@@ -1,27 +1,24 @@
 import type { SponsoredItem } from "@/lib/types";
-import {
-  MARKETING_LINK_FEE_RATE,
-  SPONSOR_SHIPPING_FEE,
-  SPONSOR_SHIPPING_COST,
-} from "@/lib/config";
+import { SPONSOR_SHIPPING_FEE } from "@/lib/config";
 
 /**
- * 협찬 제품 1개당 순 광고비 계산.
+ * 협찬 제품 1개당 비용 계산.
  *
- * 공식: (단가 + 고객배송비) × (VAT 10% + 수수료율) + 실배송비
+ * 공식: (단가 + 고객배송비) × 1.1
  *
- * 구성요소:
- * - (단가 + 고객배송비) × 0.1   → 업체 선지급 부가세
- * - (단가 + 고객배송비) × 수수료 → 네이버가 가져가는 수수료
- * - 실배송비(3,300)              → 고객배송비(3,000)와의 차액 + 배송비 부가세
+ * 협찬은 사용자가 업체에 (단가 + 배송비) × 1.1을 미리 입금하고,
+ * 리뷰어가 스토어에서 (단가 + 배송비)로 결제하여 그 금액이 매출로 잡히는 구조.
+ * 매출에 부풀려져 들어간 사용자 자가 입금분을 순이익에서 환불 처리하기 위해
+ * 협찬 비용으로 동일 금액을 차감한다.
  *
- * ※ 재료비는 플랫폼 매출 계산에서 이미 차감되므로 여기에 포함하지 않음
+ * - (단가 + 배송비)       → 매출에 잡힌 협찬 분 환불
+ * - (단가 + 배송비) × 0.1 → 업체에 미리 떼이는 부가세 (사용자 추가 부담)
+ *
+ * ※ 정산 수수료, 배송비 차액(300원), 부자재비는 정산서/자동 계산에서 차감되므로
+ *   여기에 포함하지 않음 (이중 차감 방지)
  */
 export function calcUnitSponsorshipCost(unitPrice: number): number {
-  return Math.round(
-    (unitPrice + SPONSOR_SHIPPING_FEE) * (0.1 + MARKETING_LINK_FEE_RATE) +
-      SPONSOR_SHIPPING_COST
-  );
+  return Math.round((unitPrice + SPONSOR_SHIPPING_FEE) * 1.1);
 }
 
 /**
@@ -30,12 +27,13 @@ export function calcUnitSponsorshipCost(unitPrice: number): number {
  * → 호출자가 기존 수기 입력값을 유지할지 결정.
  */
 export function calcTotalSponsorshipCost(
-  items: SponsoredItem[]
+  items: SponsoredItem[],
 ): number | null {
   if (items.length === 0) return 0;
   if (items.some((i) => i.unitPrice == null || i.unitPrice <= 0)) return null;
   return items.reduce(
-    (sum, item) => sum + calcUnitSponsorshipCost(item.unitPrice!) * item.quantity,
-    0
+    (sum, item) =>
+      sum + calcUnitSponsorshipCost(item.unitPrice!) * item.quantity,
+    0,
   );
 }


### PR DESCRIPTION
## 관련 이슈
Closes #12

## 변경 내용
- 협찬 1개당 비용 공식을 `(단가 + 배송비) × 1.1`로 단순화
- 매출에 잡히는 협찬 분과 업체 부가세를 순이익에서 정확히 환불 처리
- 정산 수수료/배송비 차액/부자재비는 기존 자동 차감 경로에 맡기고 공식에서 제외 (이중 차감 방지)
- 카드 툴팁 문구를 새 공식과 의도에 맞춰 갱신
- 기존 저장 레포트 일괄 재계산 스크립트 추가

## 코드 리뷰 결과
- [x] 보안 감사 통과 (크리덴셜/민감 정보 노출 없음)
- [x] 타입 안전성 확인 (`any` 없음, `tsc --noEmit` 통과)
- [x] 컨벤션 점검 완료 (config.ts 통한 상수 import 유지)
- [x] 코드 품질 확인

## 테스트
- [x] `npx vitest run src/lib/calculations/sponsorship.test.ts` (11개 모두 통과)
- [x] `npx tsc --noEmit` 오류 없음
- [ ] 마이그레이션 스크립트 실행 후 임의 월 검증 (별도)
- [ ] UI에서 카드 툴팁 문구 확인 (별도)